### PR TITLE
Fix broken link to Introduction video

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![AC Studio ](https://madewithcards.blob.core.windows.net/uploads/29bb3d02-2158-40b8-8420-4dd1f15da34c-acstudio.png)
 
-![Watch the introduction Video on Youtube](https://www.youtube.com/watch?v=pMoy1peu81Q)
+🎥 [Watch the introduction Video on Youtube ](https://www.youtube.com/watch?v=pMoy1peu81Q)
 
 
 ## Features


### PR DESCRIPTION
Merging this PR will 

- Fix the broken link to the Introduction video

The link is currently rendered with a target of `https://camo.githubusercontent.com/6036ede2294e1b5585e984d5dadd3cb3ba39a706e46161b57164740c6eee8d6b/68747470733a2f2f7777772e796f75747562652e636f6d2f77617463683f763d704d6f7931706575383151` which produces an error page with the message `Non-Image content-type returned` when clicked.