### PR TITLE
add box-shadow for microsoft-teams to make card preview be clear

### DIFF
--- a/media/css/additional/microsoft-teams-dark.css
+++ b/media/css/additional/microsoft-teams-dark.css
@@ -36,6 +36,7 @@
 .teams-inner-frame {
     background-color: #2D2B2C;
     border-radius: 4px;
+    box-shadow: 0 25px 57px 0 rgba(0, 0, 0, .22), 0 5px 14px 0 rgba(0, 0, 0, .18);
     padding: 24px;
     min-width: 400px;
     max-width: 726px;

--- a/media/css/additional/microsoft-teams-light.css
+++ b/media/css/additional/microsoft-teams-light.css
@@ -36,6 +36,7 @@
 .teams-inner-frame {
     background-color: white;
     border-radius: 4px;
+    box-shadow: 0 25px 57px 0 rgba(0, 0, 0, .22), 0 5px 14px 0 rgba(0, 0, 0, .18);
     padding: 24px;
     min-width: 400px;
     max-width: 726px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1050213/236124528-3a3c66c0-672d-4446-a566-f679618f970c.png)


After:
![image](https://user-images.githubusercontent.com/1050213/236124403-e8b996a1-7296-47ac-9548-f7ec2ef2acab.png)
