### PR TITLE
Automatically preview card when opening Data file directly after launching VS Code

### DIFF
--- a/src/adaptiveCards.ts
+++ b/src/adaptiveCards.ts
@@ -241,7 +241,7 @@ export class AdaptiveCardsMain {
             return;
         }
 
-        let text: string, data: string = "";
+        let text: string = "", data: string = "";
         // when a data file is edited, get text from json template instead
         // when a template is edited, get data from json.data instead
         if(activeEditor.document.fileName.endsWith(".data.json")) {


### PR DESCRIPTION
Before:
When open Visual Studio Code and click Data of the card directly (hasn't click to view template before), the card won't be previewed automatically.

![image](https://user-images.githubusercontent.com/86260893/236611609-6dbafe39-94a6-435e-b2b1-902cd2599296.png)



After:
If reload VS Code window and click to view Data file, the card can be previewed automatically
![image](https://user-images.githubusercontent.com/86260893/236611579-ae64422a-2f71-4956-a7f8-3675ad14a2c3.png)
